### PR TITLE
Solves hasher cannot read property of null

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,6 +318,8 @@ var IOClusterClient = module.exports.IOClusterClient = function (options) {
   var hasher = function (str) {
     var ch;
     var hash = 0;
+    // Solves TypeError: Cannot read property 'length' of null
+    if ((str === null) || (str === undefined)) return hash;
     if (str.length == 0) return hash;
     for (var i = 0; i < str.length; i++) {
       ch = str.charCodeAt(i);


### PR DESCRIPTION
Running iocluster on FreeBSD server, the hasher function gives a null str entails in worker crash. 

This is tested in FreeBSD x64 10 and solves this problem.
